### PR TITLE
Support new operand: #{el-uid.category-option-combo-uid.attribute-option-combo-uid}

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.comparator.ObjectStringValueComparator;
+import org.hisp.dhis.dataelement.DataElementCategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElementOperand;
 
 import com.google.common.collect.Sets;
@@ -66,7 +67,7 @@ public class DimensionalObjectUtils
      * Matching data element operand, program data element, program attribute,
      * data set reporting rate metric.
      */
-    private static final Pattern COMPOSITE_DIM_OBJECT_PATTERN = Pattern.compile( "([a-zA-Z]\\w{10})\\.(\\w{5,30})" );
+    private static final Pattern COMPOSITE_DIM_OBJECT_PATTERN = Pattern.compile( "([a-zA-Z]\\w{10})\\.(\\w{5,30})\\.?(\\w{0,30})" );
     
     public static List<DimensionalObject> getCopies( List<DimensionalObject> dimensions )
     {
@@ -432,7 +433,6 @@ public class DimensionalObjectUtils
             if ( value != null )
             {
                 String val = String.valueOf( value );
-                
                 BaseDimensionalItemObject nameableObject = new BaseDimensionalItemObject( val );
                 nameableObject.setShortName( val );
                 objects.add( nameableObject );
@@ -490,6 +490,28 @@ public class DimensionalObjectUtils
         return set;
     }
     
+    /**
+     * Gets a set of unique attribute option combos based on the given collection
+     * of operands.
+     *
+     * @param operands the collection of operands.
+     * @return a set of attribute option combos.
+     */
+    public static Set<DimensionalItemObject> getAttributeOptionCombos( Collection<DataElementOperand> operands )
+    {
+        Set<DimensionalItemObject> set = Sets.newHashSet();
+        DataElementCategoryOptionCombo attributeOptionCombo;
+
+        for ( DataElementOperand operand : operands )
+        {
+            if ( (attributeOptionCombo = operand.getAttributeOptionCombo()) != null ) {
+                set.add(attributeOptionCombo);
+            }
+        }
+
+        return set;
+    }
+
     /**
      * Returns a dimension item identifier for the given data set identifier and
      * reporting date metric.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperand.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperand.java
@@ -74,6 +74,7 @@ public class DataElementOperand
     private static final String TYPE_TOTAL = "total";
 
     private static final String SPACE = " ";
+    private static final String SECTION_SEPARATOR = " and ";
     private static final String COLUMN_PREFIX = "de";
     private static final String COLUMN_SEPARATOR = "_";
 
@@ -85,6 +86,8 @@ public class DataElementOperand
 
     private DataElementCategoryOptionCombo categoryOptionCombo;
 
+    private DataElementCategoryOptionCombo attributeOptionCombo;
+
     // -------------------------------------------------------------------------
     // Transient properties
     // -------------------------------------------------------------------------
@@ -92,6 +95,8 @@ public class DataElementOperand
     private String dataElementId;
 
     private String optionComboId;
+
+    private String attributeComboId;
 
     private String operandId;
 
@@ -126,18 +131,41 @@ public class DataElementOperand
         this.categoryOptionCombo = categoryOptionCombo;
     }
 
+    public DataElementOperand( DataElement dataElement,
+                               DataElementCategoryOptionCombo categoryOptionCombo,
+                               DataElementCategoryOptionCombo attributeOptionCombo )
+    {
+        this.dataElement = dataElement;
+        this.categoryOptionCombo = categoryOptionCombo;
+        this.attributeOptionCombo = attributeOptionCombo;
+    }
+
+    private String buildOperandId() {
+        return dataElementId + SEPARATOR + optionComboId +
+            (attributeComboId != null ? SEPARATOR + attributeComboId : "");
+    }
+
     public DataElementOperand( String dataElementId, String optionComboId )
     {
         this.dataElementId = dataElementId;
         this.optionComboId = optionComboId;
-        this.operandId = dataElementId + SEPARATOR + optionComboId;
+        this.operandId = buildOperandId();
     }
 
-    public DataElementOperand( String dataElementId, String optionComboId, String operandName )
+    public DataElementOperand( String dataElementId, String optionComboId, String attributeComboId )
     {
         this.dataElementId = dataElementId;
         this.optionComboId = optionComboId;
-        this.operandId = dataElementId + SEPARATOR + optionComboId;
+        this.attributeComboId = attributeComboId;
+        this.operandId = buildOperandId();
+    }
+
+    public DataElementOperand( String dataElementId, String optionComboId, String attributeComboId, String operandName )
+    {
+        this.dataElementId = dataElementId;
+        this.optionComboId = optionComboId;
+        this.attributeComboId = attributeComboId;
+        this.operandId = buildOperandId();
         this.operandName = operandName;
     }
 
@@ -146,7 +174,7 @@ public class DataElementOperand
     {
         this.dataElementId = dataElementId;
         this.optionComboId = optionComboId;
-        this.operandId = dataElementId + SEPARATOR + optionComboId;
+        this.operandId = buildOperandId();
         this.operandName = operandName;
         this.aggregationType = aggregationType;
         this.aggregationLevels = aggregationLevels;
@@ -164,11 +192,19 @@ public class DataElementOperand
 
         if ( dataElement != null )
         {
-            item = dataElement.getUid() + ( categoryOptionCombo != null ? ( SEPARATOR + categoryOptionCombo.getUid() ) : StringUtils.EMPTY );
+            item = dataElement.getUid() +
+                ( categoryOptionCombo != null ?
+                    ( SEPARATOR + categoryOptionCombo.getUid() ) : StringUtils.EMPTY ) +
+                ( attributeOptionCombo != null ?
+                    ( SEPARATOR + attributeOptionCombo.getUid() ) : StringUtils.EMPTY );
         }
         else if ( dataElementId != null )
         {
-            item = dataElementId + ( optionComboId != null ? ( SEPARATOR + optionComboId ) : StringUtils.EMPTY );
+            item = dataElementId +
+                ( optionComboId != null ?
+                    ( SEPARATOR + optionComboId ) : StringUtils.EMPTY ) +
+                ( attributeComboId != null ?
+                    ( SEPARATOR + attributeComboId ) : StringUtils.EMPTY );
         }
         
         return item;
@@ -210,6 +246,11 @@ public class DataElementOperand
             name += SPACE + categoryOptionCombo.getName();
         }
 
+        if ( attributeOptionCombo != null && !attributeOptionCombo.isDefault() )
+        {
+            name += SECTION_SEPARATOR + attributeOptionCombo.getName();
+        }
+
         return name;
     }
 
@@ -226,6 +267,11 @@ public class DataElementOperand
         if ( categoryOptionCombo != null )
         {
             shortName += SPACE + categoryOptionCombo.getName();
+        }
+
+        if ( attributeOptionCombo != null )
+        {
+            shortName += SECTION_SEPARATOR + attributeOptionCombo.getName();
         }
 
         return shortName;
@@ -288,7 +334,7 @@ public class DataElementOperand
     }
 
     /**
-     * Returns the operand expression which is on the format #{de-uid.coc-uid} .
+     * Returns the operand expression which is on the format #{de-uid.coc-uid[.aoc-uid]} .
      *
      * @return the operand expression.
      */
@@ -299,14 +345,16 @@ public class DataElementOperand
         if ( dataElementId != null )
         {
             String coc = optionComboId != null ? SEPARATOR + optionComboId : "";
+            String aoc = attributeComboId != null ? SEPARATOR + attributeComboId : "";
 
-            expression = "#{" + dataElementId + coc + "}";
+            expression = "#{" + dataElementId + coc + aoc + "}";
         }
         else if ( dataElement != null )
         {
             String coc = categoryOptionCombo != null ? SEPARATOR + categoryOptionCombo.getUid() : "";
+            String aoc = attributeOptionCombo != null ? SEPARATOR + attributeOptionCombo.getUid() : "";
 
-            expression = "#{" + dataElement.getUid() + coc + "}";
+            expression = "#{" + dataElement.getUid() + coc + aoc + "}";
         }
 
         return expression;
@@ -319,7 +367,7 @@ public class DataElementOperand
      */
     public String getColumnName()
     {
-        return COLUMN_PREFIX + dataElementId + COLUMN_SEPARATOR + optionComboId;
+        return COLUMN_PREFIX + dataElementId + COLUMN_SEPARATOR + optionComboId + COLUMN_SEPARATOR + attributeComboId;
     }
 
     /**
@@ -328,9 +376,10 @@ public class DataElementOperand
      *
      * @param dataElement         the data element.
      * @param categoryOptionCombo the category option combo.
+     * @param attributeOptionCombo the attribute category option combo.
      * @return the name.
      */
-    public static String getPrettyName( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo )
+    public static String getPrettyName( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo, DataElementCategoryOptionCombo attributeOptionCombo )
     {
         if ( dataElement == null ) // Invalid
         {
@@ -342,7 +391,17 @@ public class DataElementOperand
             return dataElement.getDisplayName() + SPACE + NAME_TOTAL;
         }
 
-        return categoryOptionCombo.isDefault() ? dataElement.getDisplayName() : dataElement.getDisplayName() + SPACE + categoryOptionCombo.getName();
+        if (categoryOptionCombo.isDefault() )
+        {
+            return dataElement.getDisplayName();
+        }
+
+        if ( attributeOptionCombo == null || attributeOptionCombo.isDefault() ) {
+            return dataElement.getDisplayName() + SPACE + categoryOptionCombo.getName();
+        }
+
+        return dataElement.getDisplayName() + SPACE + categoryOptionCombo.getName() +
+            SECTION_SEPARATOR + attributeOptionCombo.getName();
     }
 
     /**
@@ -352,7 +411,7 @@ public class DataElementOperand
      */
     public String getPrettyName()
     {
-        return getPrettyName( dataElement, categoryOptionCombo );
+        return getPrettyName( dataElement, categoryOptionCombo, attributeOptionCombo );
     }
 
     /**
@@ -370,21 +429,23 @@ public class DataElementOperand
      *
      * @param dataElement
      * @param categoryOptionCombo
+     * @param attributeOptionCombo
      */
-    public void updateProperties( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo )
+    public void updateProperties( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo, DataElementCategoryOptionCombo attributeOptionCombo )
     {
         this.dataElementId = dataElement.getUid();
         this.optionComboId = categoryOptionCombo.getUid();
-        this.operandId = dataElementId + SEPARATOR + optionComboId;
-        this.operandName = getPrettyName( dataElement, categoryOptionCombo );
+        this.attributeComboId = attributeOptionCombo != null ? attributeOptionCombo.getUid() : null;
+        this.operandId = buildOperandId();
+        this.operandName = getPrettyName( dataElement, categoryOptionCombo, attributeOptionCombo );
         this.legendSet = dataElement.getLegendSet();
         this.aggregationType = dataElement.getAggregationType();
         this.valueType = dataElement.getValueType();
         this.frequencyOrder = dataElement.getFrequencyOrder();
         this.aggregationLevels = new ArrayList<>( dataElement.getAggregationLevels() );
 
-        this.uid = dataElementId + SEPARATOR + optionComboId;
-        this.name = getPrettyName( dataElement, categoryOptionCombo );
+        this.uid = buildOperandId();
+        this.name = getPrettyName( dataElement, categoryOptionCombo, attributeOptionCombo );
     }
 
     /**
@@ -396,7 +457,7 @@ public class DataElementOperand
     {
         this.dataElementId = dataElement.getUid();
         this.operandId = String.valueOf( dataElementId );
-        this.operandName = getPrettyName( dataElement, null );
+        this.operandName = getPrettyName( dataElement, null, null );
         this.legendSet = dataElement.getLegendSet();
         this.aggregationType = dataElement.getAggregationType();
         this.valueType = dataElement.getValueType();
@@ -404,12 +465,13 @@ public class DataElementOperand
         this.aggregationLevels = new ArrayList<>( dataElement.getAggregationLevels() );
 
         this.uid = dataElementId;
-        this.name = getPrettyName( dataElement, null );
+        this.name = getPrettyName( dataElement, null, null );
     }
 
     /**
      * Generates a DataElementOperand based on the given formula. The formula
-     * needs to be on the form "#{<dataelementid>.<categoryoptioncomboid>}".
+     * needs to be on the form "#{<dataelementid>.<categoryoptioncomboid>}" or
+     * "#{<dataelementid>.<categoryoptioncomboid>.<attributeoptioncomboid>}".
      *
      * @param expression the formula.
      * @return a DataElementOperand.
@@ -421,9 +483,12 @@ public class DataElementOperand
         matcher.find();
         String dataElement = StringUtils.trimToNull( matcher.group( 1 ) );
         String categoryOptionCombo = StringUtils.trimToNull( matcher.group( 2 ) );
-        String operandType = categoryOptionCombo != null ? TYPE_VALUE : TYPE_TOTAL;
+        String attributeOptionCombo = StringUtils.trimToNull( matcher.group( 3 ) );
+        String operandType =
+            categoryOptionCombo != null || attributeOptionCombo != null ? TYPE_VALUE : TYPE_TOTAL;
 
-        final DataElementOperand operand = new DataElementOperand( dataElement, categoryOptionCombo );
+        final DataElementOperand operand =
+            new DataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
         operand.setOperandType( operandType );
         return operand;
     }
@@ -461,6 +526,20 @@ public class DataElementOperand
     }
 
     @JsonProperty
+    @JsonSerialize( as = BaseIdentifiableObject.class )
+    @JsonView( { DetailedView.class, ExportView.class } )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public DataElementCategoryOptionCombo getAttributeOptionCombo()
+    {
+        return attributeOptionCombo;
+    }
+
+    public void setAttributeOptionCombo( DataElementCategoryOptionCombo attributeOptionCombo )
+    {
+        this.attributeOptionCombo = attributeOptionCombo;
+    }
+
+    @JsonProperty
     @JsonView( { DetailedView.class } )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDataElementId()
@@ -484,6 +563,19 @@ public class DataElementOperand
     public void setOptionComboId( String optionComboId )
     {
         this.optionComboId = optionComboId;
+    }
+
+    @JsonProperty
+    @JsonView( { DetailedView.class } )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getAttributeComboId()
+    {
+        return attributeComboId;
+    }
+
+    public void setAttributeComboId( String attributeComboId )
+    {
+        this.attributeComboId = attributeComboId;
     }
 
     @JsonProperty
@@ -591,6 +683,7 @@ public class DataElementOperand
             "\"uid\":\"" + uid + "\", " +
             "\"dataElement\":" + dataElement + ", " +
             "\"categoryOptionCombo\":" + categoryOptionCombo + ", " +
+            "\"attributeOptionCombo\":" + attributeOptionCombo + ", " +
             "\"dataElementId\":\"" + dataElementId + "\", " +
             "\"optionComboId\":\"" + optionComboId + "\", " +
             "\"operandId\":\"" + operandId + "\", " +
@@ -607,6 +700,7 @@ public class DataElementOperand
 
         result = prime * result + ((dataElement == null) ? 0 : dataElement.hashCode());
         result = prime * result + ((categoryOptionCombo == null) ? 0 : categoryOptionCombo.hashCode());
+        result = prime * result + ((attributeOptionCombo == null) ? 0 : attributeOptionCombo.hashCode());
         result = prime * result + ((dataElementId == null) ? 0 : dataElementId.hashCode());
         result = prime * result + ((optionComboId == null) ? 0 : optionComboId.hashCode());
 
@@ -657,6 +751,18 @@ public class DataElementOperand
             return false;
         }
 
+        if ( attributeOptionCombo == null )
+        {
+            if ( other.attributeOptionCombo != null )
+            {
+                return false;
+            }
+        }
+        else if ( !attributeOptionCombo.equals( other.attributeOptionCombo ) )
+        {
+            return false;
+        }
+
         if ( dataElementId == null )
         {
             if ( other.dataElementId != null )
@@ -681,6 +787,18 @@ public class DataElementOperand
             return false;
         }
 
+        if ( attributeComboId == null )
+        {
+            if ( other.attributeComboId != null )
+            {
+                return false;
+            }
+        }
+        else if ( !attributeComboId.equals( other.attributeComboId ) )
+        {
+            return false;
+        }
+
         return true;
     }
 
@@ -694,6 +812,11 @@ public class DataElementOperand
             return this.dataElementId.compareTo( other.dataElementId );
         }
 
+        if ( this.optionComboId.compareTo( other.optionComboId ) != 0 )
+        {
         return this.optionComboId.compareTo( other.optionComboId );
+    }
+
+        return this.attributeComboId.compareTo( other.attributeComboId );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperandService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperandService.java
@@ -54,9 +54,24 @@ public interface DataElementOperandService
     
     DataElementOperand getDataElementOperand( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo );
     
+    DataElementOperand getDataElementOperand( DataElement dataElement,
+                                              DataElementCategoryOptionCombo categoryOptionCombo,
+                                              DataElementCategoryOptionCombo attributeOptionCombo);
+
     DataElementOperand getDataElementOperand( String dataElementUid, String categoryOptionComboUid );
     
+    DataElementOperand getDataElementOperand( String dataElementUid, String categoryOptionComboUid,
+                                              String attributeOptionComboUid);
+
     DataElementOperand getOrAddDataElementOperand( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo );
     
+    DataElementOperand getOrAddDataElementOperand( DataElement dataElement,
+                                                   DataElementCategoryOptionCombo categoryOptionCombo,
+                                                   DataElementCategoryOptionCombo attributeOptionCombo );
+
     DataElementOperand getOrAddDataElementOperand( String dataElementUid, String categoryOptionComboUid );
+
+    DataElementOperand getOrAddDataElementOperand( String dataElementUid,
+                                                   String categoryOptionComboUid,
+                                                   String attributeOptionComboUid );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperandStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperandStore.java
@@ -39,4 +39,8 @@ public interface DataElementOperandStore
     String ID = DataElementOperand.class.getName();
 
     DataElementOperand get( DataElement dataElement, DataElementCategoryOptionCombo categoryOptionCombo );
+
+    DataElementOperand get( DataElement dataElement,
+                            DataElementCategoryOptionCombo categoryOptionCombo,
+                            DataElementCategoryOptionCombo attributeOptionCombo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -71,12 +71,12 @@ public interface ExpressionService
     String SPACE = " ";
     String DAYS_SYMBOL = "[days]";
 
-    String VARIABLE_EXPRESSION = "(#|D|A|I)\\{(([a-zA-Z]\\w{10})\\.?(\\w*))\\}";
-    String OPERAND_EXPRESSION = "#\\{([a-zA-Z]\\w{10})\\.?(\\w*)\\}";
+    String VARIABLE_EXPRESSION = "(#|D|A|I)\\{(([a-zA-Z]\\w{10})\\.?(\\w*)\\.?(\\w*))\\}";
+    String OPERAND_EXPRESSION = "#\\{([a-zA-Z]\\w{10})\\.?(\\w*)\\.?(\\w*)\\}";
     String PROGRAM_DATA_ELEMENT_EXPRESSION = "D\\{([a-zA-Z]\\w{10})\\.?([a-zA-Z]\\w{10})\\}";
     String OPERAND_UID_EXPRESSION = "([a-zA-Z]\\w{10})\\.?(\\w*)";
     String DATA_ELEMENT_TOTAL_EXPRESSION = "#\\{([a-zA-Z]\\w{10})\\}";
-    String OPTION_COMBO_OPERAND_EXPRESSION = "#\\{([a-zA-Z]\\w{10})\\.([a-zA-Z]\\w{10})\\}";
+    String OPTION_COMBO_OPERAND_EXPRESSION = "#\\{([a-zA-Z]\\w{10})\\.([a-zA-Z]\\w{10})\\.?([a-zA-Z]\\w{10})?\\}";
     String CONSTANT_EXPRESSION = "C\\{([a-zA-Z]\\w{10})\\}";
     String OU_GROUP_EXPRESSION = "OUG\\{([a-zA-Z]\\w{10})\\}";
     String DAYS_EXPRESSION = "\\[days\\]";

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/DimensionalObjectUtilsTest.java
@@ -51,6 +51,7 @@ public class DimensionalObjectUtilsTest
     public void testIsCompositeDimensionObject()
     {
         assertTrue( DimensionalObjectUtils.isCompositeDimensionalObject( "d4HjsAHkj42.G142kJ2k3Gj" ) );
+        assertTrue( DimensionalObjectUtils.isCompositeDimensionalObject( "d4HjsAHkj42.G142kJ2k3Gj.kC1OT9Q1n1j" ) );
         
         assertFalse( DimensionalObjectUtils.isCompositeDimensionalObject( "d4HjsAHkj42" ) );
         assertFalse( DimensionalObjectUtils.isCompositeDimensionalObject( "14HjsAHkj42-G142kJ2k3Gj" ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsUtils.java
@@ -185,16 +185,22 @@ public class AnalyticsUtils
      * i.e. "deuid-cocuid" to "deuid.cocuid".
      * 
      * @param valueMap the value map to convert.
+     * @param count number of replacements to perform
      * @return a value map.
      */
-    public static <T> Map<String, T> convertDxToOperand( Map<String, T> valueMap )
+    public static <T> Map<String, T> convertDxToOperand( Map<String, T> valueMap, Integer count )
     {
         Map<String, T> map = Maps.newHashMap();
         
         for ( Entry<String, T> entry : valueMap.entrySet() )
         {
-            map.put( entry.getKey().replaceFirst( DimensionalObject.DIMENSION_SEP, 
-                DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP ), entry.getValue() );
+            String key = entry.getKey();
+            for ( int i = 0; i < count; i++ )
+            {
+                key = key.replaceFirst( DimensionalObject.DIMENSION_SEP,
+                    DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP );
+            }
+            map.put( key, entry.getValue() );
         }
         
         return map;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.common.DimensionType.DATA_X;
 import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
 import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT_GROUP_SET;
 import static org.hisp.dhis.common.DimensionType.PERIOD;
+import static org.hisp.dhis.common.DimensionalObject.ATTRIBUTEOPTIONCOMBO_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.CATEGORYOPTIONCOMBO_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
@@ -109,6 +110,7 @@ public class DataQueryParams
 
     public static final int DX_INDEX = 0;
     public static final int CO_INDEX = 1;
+    public static final int AO_INDEX = 2;
 
     public static final Set<Class<? extends IdentifiableObject>> DYNAMIC_DIM_CLASSES = ImmutableSet.<Class<? extends IdentifiableObject>>builder().
         add( OrganisationUnitGroupSet.class ).add( DataElementGroupSet.class ).add( CategoryOptionGroupSet.class ).add( DataElementCategory.class ).build();
@@ -1125,6 +1127,15 @@ public class DataQueryParams
         {
             int index = !dimensions.isEmpty() && DATA_X_DIM_ID.equals( dimensions.get( 0 ).getDimension() ) ? CO_INDEX : DX_INDEX;
             
+            dimensions.add( index, dimension );
+        }
+        else if ( ATTRIBUTEOPTIONCOMBO_DIM_ID.equals( dimension.getDimension() ) )
+        {
+            int index = dimensions.size() > 1 &&
+                DATA_X_DIM_ID.equals( dimensions.get( 0 ).getDimension() ) &&
+                CATEGORYOPTIONCOMBO_DIM_ID.equals( dimensions.get( 1 ).getDimension() )
+                ? AO_INDEX : DX_INDEX;
+
             dimensions.add( index, dimension );
         }
         else

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/AnalyticsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/AnalyticsUtilsTest.java
@@ -76,15 +76,21 @@ public class AnalyticsUtilsTest
     public void testConvertDxToOperand()
     {
         Map<String, Double> map = new HashMap<>();
-        map.put( "GauDLAiXPKT-kC1OT9Q1n1j-R9U8q7X1aJG", 10d );
+        map.put( "GauDLAiXPKT-kC1OT9Q1n1j", 10d );
         map.put( "YkRvCLedQa4-h1dJ9W4dWor-Zrd4DAf8M99", 11d );
-        map.put( "PcfRp1HETO8-zqXKIEycBck-KBJBZopYMPV", 12d );
+        map.put( "PcfRp1HETO8-zqXKIEycBck-KBJBZopYMPV-Prlt0C1RF0s", 12d );
         
-        Map<String, Double> convertedMap = AnalyticsUtils.convertDxToOperand( map );
+        Map<String, Double> convertedMap1 = AnalyticsUtils.convertDxToOperand( map, 1 );
         
-        assertTrue( convertedMap.containsKey( "GauDLAiXPKT.kC1OT9Q1n1j-R9U8q7X1aJG" ) );
-        assertTrue( convertedMap.containsKey( "YkRvCLedQa4.h1dJ9W4dWor-Zrd4DAf8M99" ) );
-        assertTrue( convertedMap.containsKey( "PcfRp1HETO8.zqXKIEycBck-KBJBZopYMPV" ) );
+        assertTrue( convertedMap1.containsKey( "GauDLAiXPKT.kC1OT9Q1n1j" ) );
+        assertTrue( convertedMap1.containsKey( "YkRvCLedQa4.h1dJ9W4dWor-Zrd4DAf8M99" ) );
+        assertTrue( convertedMap1.containsKey( "PcfRp1HETO8.zqXKIEycBck-KBJBZopYMPV-Prlt0C1RF0s" ) );
+
+        Map<String, Double> convertedMap2 = AnalyticsUtils.convertDxToOperand( map, 2 );
+
+        assertTrue( convertedMap2.containsKey( "GauDLAiXPKT.kC1OT9Q1n1j" ) );
+        assertTrue( convertedMap2.containsKey( "YkRvCLedQa4.h1dJ9W4dWor.Zrd4DAf8M99" ) );
+        assertTrue( convertedMap2.containsKey( "PcfRp1HETO8.zqXKIEycBck.KBJBZopYMPV-Prlt0C1RF0s" ) );
     }
     
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementCategoryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementCategoryService.java
@@ -37,10 +37,8 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.i18n.I18nService;
 import org.hisp.dhis.user.UserCredentials;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -62,9 +60,6 @@ public class DefaultDataElementCategoryService
     implements DataElementCategoryService
 {
     private static final Log log = LogFactory.getLog( DefaultDataElementCategoryService.class );
-
-    @Autowired
-    private DataSetService dataSetService;
 
     // -------------------------------------------------------------------------
     // Dependencies

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementOperandService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementOperandService.java
@@ -155,6 +155,14 @@ public class DefaultDataElementOperandService
     }
     
     @Override
+    public DataElementOperand getDataElementOperand( DataElement dataElement,
+                                                     DataElementCategoryOptionCombo categoryOptionCombo,
+                                                     DataElementCategoryOptionCombo attributeOptionCombo)
+    {
+        return dataElementOperandStore.get( dataElement, categoryOptionCombo, attributeOptionCombo);
+    }
+
+    @Override
     public DataElementOperand getDataElementOperand( String dataElementUid, String categoryOptionComboUid )
     {
         DataElement dataElement = dataElementService.getDataElement( dataElementUid );
@@ -166,6 +174,25 @@ public class DefaultDataElementOperandService
         }
         
         return new DataElementOperand( dataElement, categoryOptionCombo );
+    }
+
+    @Override
+    public DataElementOperand getDataElementOperand( String dataElementUid,
+                                                     String categoryOptionComboUid,
+                                                     String attributeOptionComboUid)
+    {
+        DataElement dataElement = dataElementService.getDataElement( dataElementUid );
+        DataElementCategoryOptionCombo categoryOptionCombo =
+            categoryService.getDataElementCategoryOptionCombo( categoryOptionComboUid );
+        DataElementCategoryOptionCombo attributeOptionCombo =
+            categoryService.getDataElementCategoryOptionCombo( attributeOptionComboUid );
+
+        if ( dataElement == null || categoryOptionCombo == null || attributeOptionCombo == null)
+        {
+            return null;
+        }
+
+        return new DataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo  );
     }
 
     @Override
@@ -184,6 +211,23 @@ public class DefaultDataElementOperandService
     }
 
     @Override
+    public DataElementOperand getOrAddDataElementOperand( DataElement dataElement,
+        DataElementCategoryOptionCombo categoryOptionCombo, DataElementCategoryOptionCombo attributeOptionCombo )
+    {
+        DataElementOperand operand =
+            getDataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
+
+        if ( operand == null )
+        {
+            operand = new DataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
+
+            addDataElementOperand( operand );
+        }
+
+        return operand;
+    }
+
+    @Override
     public DataElementOperand getOrAddDataElementOperand( String dataElementUid, String categoryOptionComboUid )
     {
         DataElement dataElement = dataElementService.getDataElement( dataElementUid );
@@ -195,5 +239,24 @@ public class DefaultDataElementOperandService
         }
         
         return getOrAddDataElementOperand( dataElement, categoryOptionCombo );
+    }
+
+    @Override
+    public DataElementOperand getOrAddDataElementOperand( String dataElementUid,
+                                                          String categoryOptionComboUid,
+                                                          String attributeOptionComboUid )
+    {
+        DataElement dataElement = dataElementService.getDataElement( dataElementUid );
+        DataElementCategoryOptionCombo categoryOptionCombo =
+            categoryService.getDataElementCategoryOptionCombo( categoryOptionComboUid );
+        DataElementCategoryOptionCombo attributeOptionCombo =
+            categoryService.getDataElementCategoryOptionCombo( attributeOptionComboUid );
+
+        if ( dataElement == null || categoryOptionCombo == null || attributeOptionCombo == null)
+        {
+            return null;
+        }
+
+        return getOrAddDataElementOperand( dataElement, categoryOptionCombo, attributeOptionCombo );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/hibernate/HibernateDataElementOperandStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/hibernate/HibernateDataElementOperandStore.java
@@ -68,4 +68,18 @@ public class HibernateDataElementOperandStore
         
         return !operands.isEmpty() ? operands.get( 0 ) : null;
     }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public DataElementOperand get( DataElement dataElement,
+                                   DataElementCategoryOptionCombo categoryOptionCombo,
+                                   DataElementCategoryOptionCombo attributeOptionCombo )
+    {
+        List<DataElementOperand> operands = getCriteria(
+            Restrictions.eq( "dataElement", dataElement ),
+            Restrictions.eq( "categoryOptionCombo", categoryOptionCombo ),
+            Restrictions.eq( "attributeOptionCombo", attributeOptionCombo ) ).list();
+
+        return !operands.isEmpty() ? operands.get( 0 ) : null;
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -337,13 +337,18 @@ public class DefaultDimensionService
         {
             String id0 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 0 );
             String id1 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 1 );
+            String id2 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 2 );
 
             DataElementOperand operand = null;
             DataSet dataSet = null;
             ProgramDataElement programDataElement = null;
             ProgramTrackedEntityAttribute programAttribute = null;
             
-            if ( ( operand = operandService.getOrAddDataElementOperand( id0, id1 ) ) != null )
+            if ( id2 != null )
+            {
+                return operandService.getOrAddDataElementOperand( id0, id1, id2 );
+            }
+            else if ( ( operand = operandService.getOrAddDataElementOperand( id0, id1 ) ) != null )
             {
                 return operand;
             }
@@ -390,13 +395,18 @@ public class DefaultDimensionService
         {
             String id0 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 0 );
             String id1 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 1 );
+            String id2 = splitSafe( dimensionItem, COMPOSITE_DIM_OBJECT_ESCAPED_SEP, 2 );
 
             DataElementOperand operand = null;
             DataSet dataSet = null;
             ProgramDataElement programDataElement = null;
             ProgramTrackedEntityAttribute programAttribute = null;
 
-            if ( ( operand = operandService.getDataElementOperand( id0, id1 ) ) != null )
+            if ( id2 != null )
+            {
+                return operandService.getDataElementOperand( id0, id1, id2 );
+            }
+            else if ( ( operand = operandService.getDataElementOperand( id0, id1 ) ) != null )
             {
                 return operand;
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -214,6 +214,7 @@ public class DefaultExpressionService
         final double denominatorValue = calculateExpression( denominatorExpression );
 
         if ( !isEqual( denominatorValue, 0d ) )
+
         {
             final String numeratorExpression = generateExpression( indicator.getExplodedNumeratorFallback(), valueMap,
                 constantMap, orgUnitCountMap, days, NEVER_SKIP );
@@ -222,7 +223,6 @@ public class DefaultExpressionService
             {
                 return null;
             }
-
             final double numeratorValue = calculateExpression( numeratorExpression );
 
             final double annualizationFactor = period != null
@@ -324,6 +324,14 @@ public class DefaultExpressionService
                 if ( categoryOptionCombo != null )
                 {
                     optionCombosInExpression.add( categoryOptionCombo );
+                }
+
+                DataElementCategoryOptionCombo attributeOptionCombo = matcher.group( 3 ) == null ?
+                    null : categoryService.getDataElementCategoryOptionCombo( matcher.group( 3 ) );
+
+                if ( attributeOptionCombo != null )
+                {
+                    optionCombosInExpression.add( attributeOptionCombo );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElementOperand.hbm.xml
@@ -18,5 +18,11 @@
     <many-to-one name="categoryOptionCombo" class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
       column="categoryoptioncomboid" foreign-key="fk_dataelementoperand_dataelementcategoryoptioncombo" unique-key="dataelement_operand_unique_key" />
 
+    <many-to-one name="attributeOptionCombo"
+                 class="org.hisp.dhis.dataelement.DataElementCategoryOptionCombo"
+                 column="attributeoptioncomboid"
+                 foreign-key="fk_dataelementoperand_dataelementattributeoptioncombo"
+                 unique-key="dataelement_operand_unique_key" />
+
   </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -152,6 +152,7 @@ public class ExpressionServiceTest
     private String expressionK;
     private String expressionJ;
     private String expressionL;
+    private String expressionM;
 
     private String descriptionA;
     private String descriptionB;
@@ -267,6 +268,7 @@ public class ExpressionServiceTest
         expressionJ = "#{" + opA.getDimensionItem() + "}+#{" + opB.getDimensionItem() + "}";
         expressionK = "1.5*AVG("+expressionJ+")";
         expressionL = "AVG("+expressionJ+")+1.5*STDDEV("+expressionJ+")";
+        expressionM = "#{" + deA.getUid() + SEPARATOR + coc.getUid() + SEPARATOR + coc.getUid() + "}";
 
         descriptionA = "Expression A";
         descriptionB = "Expression B";
@@ -489,7 +491,6 @@ public class ExpressionServiceTest
     @Test
     public void testExpressionIsValid()
     {
-        
     	assertTrue( expressionService.expressionIsValid( expressionA ).isValid() );
         assertTrue( expressionService.expressionIsValid( expressionB ).isValid() );
         assertTrue( expressionService.expressionIsValid( expressionC ).isValid() );
@@ -498,6 +499,7 @@ public class ExpressionServiceTest
         assertTrue( expressionService.expressionIsValid( expressionH ).isValid() );
         assertTrue( expressionService.expressionIsValid( expressionK ).isValid() );
         assertTrue( expressionService.expressionIsValid( expressionL ).isValid() );
+        assertTrue( expressionService.expressionIsValid( expressionM ).isValid() );
 
         expressionA = "#{nonExisting" + SEPARATOR + coc.getUid() + "} + 12";
 
@@ -555,6 +557,7 @@ public class ExpressionServiceTest
         Map<DataElementOperand, Double> valueMap = new HashMap<>();
         valueMap.put( new DataElementOperand( deA.getUid(), coc.getUid() ), 12d );
         valueMap.put( new DataElementOperand( deB.getUid(), coc.getUid() ), 34d );
+        valueMap.put( new DataElementOperand( deA.getUid(), coc.getUid(), coc.getUid() ), 56d );
         
         Map<String, Double> constantMap = new HashMap<>();
         constantMap.put( constantA.getUid(), 2.0 );
@@ -566,6 +569,7 @@ public class ExpressionServiceTest
         assertEquals( "12.0+5", expressionService.generateExpression( expressionD, valueMap, constantMap, null, 5, null ) );
         assertEquals( "12.0*2.0", expressionService.generateExpression( expressionE, valueMap, constantMap, null, null, null ) );
         assertEquals( "12.0*3", expressionService.generateExpression( expressionH, valueMap, constantMap, orgUnitCountMap, null, null ) );
+        assertEquals( "56.0", expressionService.generateExpression( expressionM, valueMap, constantMap, null, null, null ) );
     }
 
     @Test
@@ -587,10 +591,12 @@ public class ExpressionServiceTest
         Expression expD = createExpression( 'D', expressionD, null, null );
         Expression expE = createExpression( 'E', expressionE, null, null );
         Expression expH = createExpression( 'H', expressionH, null, null );
+        Expression expM = createExpression( 'M', expressionM, null, null );
         
         Map<DataElementOperand, Double> valueMap = new HashMap<>();
         valueMap.put( new DataElementOperand( deA.getUid(), coc.getUid() ), 12d );
         valueMap.put( new DataElementOperand( deB.getUid(), coc.getUid() ), 34d );
+        valueMap.put( new DataElementOperand( deA.getUid(), coc.getUid(), coc.getUid() ), 56d );
         
         Map<String, Double> constantMap = new HashMap<>();
         constantMap.put( constantA.getUid(), 2.0 );
@@ -602,6 +608,7 @@ public class ExpressionServiceTest
         assertEquals( 17d, expressionService.getExpressionValue( expD, valueMap, constantMap, null, 5 ), DELTA );
         assertEquals( 24d, expressionService.getExpressionValue( expE, valueMap, constantMap, null, null ), DELTA );
         assertEquals( 36d, expressionService.getExpressionValue( expH, valueMap, constantMap, orgUnitCountMap, null ), DELTA );
+        assertEquals( 56d, expressionService.getExpressionValue( expM, valueMap, constantMap, null, null ), DELTA );
     }
     
     @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/objectmapper/DataElementOperandMapper.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/objectmapper/DataElementOperandMapper.java
@@ -60,6 +60,7 @@ public class DataElementOperandMapper
         final DataElementOperand operand = new DataElementOperand(
             resultSet.getString( 1 ),
             resultSet.getString( 3 ),
+            null,
             operandName );
         
         return operand;

--- a/dhis-2/dhis-web/dhis-web-validationrule/src/main/java/org/hisp/dhis/validationrule/action/GetValidationResultDetailsAction.java
+++ b/dhis-2/dhis-web/dhis-web-validationrule/src/main/java/org/hisp/dhis/validationrule/action/GetValidationResultDetailsAction.java
@@ -179,12 +179,14 @@ public class GetValidationResultDetailsAction
             DataElement dataElement = dataElementService.getDataElement( operand.getDataElementId() );
             DataElementCategoryOptionCombo categoryOptionCombo = categoryService
                 .getDataElementCategoryOptionCombo( operand.getOptionComboId() );
+            DataElementCategoryOptionCombo attributeOptionCombo = categoryService
+                .getDataElementCategoryOptionCombo( operand.getAttributeComboId() );
 
             DataValue dataValue = dataValueService.getDataValue( dataElement, period, source, categoryOptionCombo );
             
             String value = dataValue != null ? dataValue.getValue() : NULL_REPLACEMENT;
             
-            leftSideMap.put( DataElementOperand.getPrettyName( dataElement, categoryOptionCombo ), value );
+            leftSideMap.put( DataElementOperand.getPrettyName( dataElement, categoryOptionCombo, attributeOptionCombo ), value );
         }
 
         for ( DataElementOperand operand : expressionService.getOperandsInExpression( validationRule.getRightSide().getExpression() ) )
@@ -192,12 +194,14 @@ public class GetValidationResultDetailsAction
             DataElement dataElement = dataElementService.getDataElement( operand.getDataElementId() );
             DataElementCategoryOptionCombo categoryOptionCombo = categoryService
                 .getDataElementCategoryOptionCombo( operand.getOptionComboId() );
+            DataElementCategoryOptionCombo attributeOptionCombo = categoryService
+                .getDataElementCategoryOptionCombo( operand.getAttributeComboId() );
 
             DataValue dataValue = dataValueService.getDataValue( dataElement, period, source, categoryOptionCombo );
 
             String value = dataValue != null ? dataValue.getValue() : NULL_REPLACEMENT;
             
-            rightSideMap.put( DataElementOperand.getPrettyName( dataElement, categoryOptionCombo ), value );
+            rightSideMap.put( DataElementOperand.getPrettyName( dataElement, categoryOptionCombo, attributeOptionCombo ), value );
         }
 
         return SUCCESS;


### PR DESCRIPTION
Closes #19 

Some notes:
- Used `DataElementOperand` (added optional attribute-category-combo) to hold the new field. The other option is create another class only for that new operand, but this seemed overkill.
- In the indicator listing we must decide what combinations of #{de.coc-aoc} to show. While category-option-combos are directly associated with data-elements, the association with attribute-category-combo is indirect. The rule is: show all #{de.coc.aoc1} of attribute-option-combos that are associated through a data-set (http://SERVER:8080/dhis-web-maintenance-dataset) 

![dhis-a4-web-entry](https://cloud.githubusercontent.com/assets/24643/16731254/5e8efbfc-4777-11e6-82c4-8abf2c283395.png)

![dhis-a4-creating-indicator](https://cloud.githubusercontent.com/assets/24643/16731257/61f42182-4777-11e6-9b4d-cdfb79113f7c.png)

![dhis-a4-using-indicator-in-web-pivot](https://cloud.githubusercontent.com/assets/24643/16731261/646099a0-4777-11e6-82d8-73c507c9321d.png)
